### PR TITLE
Cleanup of temp files and further log spam reduction

### DIFF
--- a/PlexPostProc.sh
+++ b/PlexPostProc.sh
@@ -187,10 +187,10 @@ if [ ! -z "$1" ]; then
    mv -f "$TEMPFILENAME" "${FILENAME%.ts}.mkv" # Move completed tempfile to .grab folder/filename
    check_errs $? "Failed to move converted file: $TEMPFILENAME"
 
-   rm -f "$LOCKFILE.ppplock"* # Delete the lockfile
+   rm -f "$LOCKFILE.ppplock"* # Delete the lockfile 
    check_errs $? "Failed to remove lockfile."
 
-   # [WORKAROUND] Wait for any other post-processing scripts to complete before exiting.
+   # [WORKAROUND] Wait for any other post-processing scripts to complete before exiting. So that plex doesnt start deleting grab files.
    timeout_counter=120
    while [ true ] ; do
      if ls "$TMPFOLDER/"*".ppplock" 1> /dev/null 2>&1; then
@@ -225,6 +225,4 @@ else
    echo "********************************************************" | tee -a $LOGFILE
 fi
 
-rm -f "$LOCKFILE.ppplock"  # Only clean up own lock files, otherwise can remove one from another transcode
-
-sleep 5 #Time for things to settle down
+sleep 3 #Time for things to settle down, move commands to finish etc...

--- a/PlexPostProc.sh
+++ b/PlexPostProc.sh
@@ -89,8 +89,8 @@ if [ ! -z "$1" ]; then
 
    FILESIZE="$(ls -lh "$FILENAME" | awk '{ print $5 }')"
 
-   RANDFILENAME="$(mktemp)"  # Temporary File Name for transcoding
-   TEMPFILENAME="$RANDFILENAME.mkv"  # Temporary File Name for transcoding
+   RANDFILENAME="$(mktemp)"  # Base random name, will be used for cleanup
+   TEMPFILENAME="$RANDFILENAME.mkv"  # Random name with extension added
 
    LOCKFILE="$(mktemp)"  # [WORKAROUND] Temporary File for blocking simultaneous scripts from ending early
    touch "$LOCKFILE.ppplock" # Create the lock file

--- a/PlexPostProc.sh
+++ b/PlexPostProc.sh
@@ -30,9 +30,6 @@
 #
 #  Log:
 #     Single log is generated with timestamped transcodes.
-
-#     Note: Logs are not deleted, so some cleanup of the temp directory may be
-#       required, or a server reboot should clear this folder.
 #
 #******************************************************************************
 
@@ -92,10 +89,11 @@ if [ ! -z "$1" ]; then
 
    FILESIZE="$(ls -lh "$FILENAME" | awk '{ print $5 }')"
 
-   TEMPFILENAME="$(mktemp).mkv"  # Temporary File Name for transcoding
+   RANDFILENAME="$(mktemp)"  # Temporary File Name for transcoding
+   TEMPFILENAME="$RANDFILENAME.mkv"  # Temporary File Name for transcoding
 
-   LOCKFILE="$(mktemp).ppplock"  # [WORKAROUND] Temporary File for blocking simultaneous scripts from ending early
-   touch $LOCKFILE # Create the lock file
+   LOCKFILE="$(mktemp)"  # [WORKAROUND] Temporary File for blocking simultaneous scripts from ending early
+   touch "$LOCKFILE.ppplock" # Create the lock file
    check_errs $? "Failed to create temporary lockfile: $LOCKFILE"
 
    LOGFILE="$TMPFOLDER/plex_DVR_post_processing_log"
@@ -110,7 +108,7 @@ if [ ! -z "$1" ]; then
    # Starting Transcoding
    # ********************************************************
 
-   LOG_STRING_1="$(date +"%Y%m%d-%H%M%S"): Transcoding $FILENAME to $TEMPFILENAME\n"
+   LOG_STRING_1="\n$(date +"%Y%m%d-%H%M%S"): Transcoding $FILENAME to $TEMPFILENAME\n"
    if [[ PPP_CHECK -eq 0 ]]; then
      printf "$LOG_STRING_1" | tee -a $LOGFILE
    fi
@@ -173,7 +171,7 @@ if [ ! -z "$1" ]; then
    # Encode Done. Performing Cleanup
    # ********************************************************"
 
-   LOG_STRING_5="$(date +"%Y%m%d-%H%M%S"): Finished transcode, "
+   LOG_STRING_5="$(date +"%Y%m%d-%H%M%S"): Finished transcode,"
    if [[ PPP_CHECK -eq 0 ]]; then
        printf "$LOG_STRING_4$LOG_STRING_5" | tee -a $LOGFILE
    fi
@@ -184,7 +182,7 @@ if [ ! -z "$1" ]; then
    mv -f "$TEMPFILENAME" "${FILENAME%.ts}.mkv" # Move completed tempfile to .grab folder/filename
    check_errs $? "Failed to move converted file: $TEMPFILENAME"
 
-   rm -f "$LOCKFILE" # Delete the lockfile after completing
+   rm -f "$LOCKFILE"* # Delete the lockfile and its tmp file
    check_errs $? "Failed to remove lockfile."
 
    # [WORKAROUND] Wait for any other post-processing scripts to complete before exiting.
@@ -213,7 +211,7 @@ if [ ! -z "$1" ]; then
    if [[ PPP_CHECK -eq 1 ]]; then
        printf "$LOG_STRING_1$LOG_STRING_2$LOG_STRING_3$LOG_STRING_4$LOG_STRING_5" | tee -a $LOGFILE #Doing all together as to not stumble over multiple concurrent processes in log
    fi
-   printf "exiting. \n\n" | tee -a $LOGFILE
+   printf " exiting. \n" | tee -a $LOGFILE
 
 else
    echo "********************************************************" | tee -a $LOGFILE
@@ -222,8 +220,8 @@ else
    echo "********************************************************" | tee -a $LOGFILE
 fi
 
-rm -f "$TMPFOLDER/"*".ppplock"  # Make sure all lock files are removed, just in case there was an error somewhere in the script
-sleep 2
-rm -f "/tmp/tmp."* #Deleting other tmp files
+rm -f "$LOCKFILE.ppplock"  # Only clean up own lock files, otherwise can remove one from another transcode
+rm -f "$RANDFILENAME"
 
 sleep 5 #Time for things to settle down
+

--- a/PlexPostProc.sh
+++ b/PlexPostProc.sh
@@ -93,9 +93,11 @@ if [ ! -z "$1" ]; then
    FILESIZE="$(ls -lh "$FILENAME" | awk '{ print $5 }')"
 
    RANDFILENAME="$(mktemp)"  # Base random name, will be used for cleanup
+   rm -f "$RANDFILENAME" #Cleanup mktemp artifact
    TEMPFILENAME="$RANDFILENAME.mkv"  # Temporary File Name for transcoding
 
    LOCKFILE="$(mktemp)"  # [WORKAROUND] Temporary File for blocking simultaneous scripts from ending early
+   rm -f "$LOCKFILE" #Clean up mktemp artifact
    touch "$LOCKFILE.ppplock" # Create the lock file
    check_errs $? "Failed to create temporary lockfile: $LOCKFILE.ppplock"
 
@@ -174,7 +176,7 @@ if [ ! -z "$1" ]; then
    # Encode Done. Performing Cleanup
    # ********************************************************"
 
-   LOG_STRING_5="$(date +"%Y%m%d-%H%M%S"): Finished transcode, "
+   LOG_STRING_5="$(date +"%Y%m%d-%H%M%S"): Finished transcode,"
    if [[ PPP_CHECK -eq 0 ]]; then
        printf "$LOG_STRING_4$LOG_STRING_5" | tee -a $LOGFILE
    fi
@@ -185,7 +187,7 @@ if [ ! -z "$1" ]; then
    mv -f "$TEMPFILENAME" "${FILENAME%.ts}.mkv" # Move completed tempfile to .grab folder/filename
    check_errs $? "Failed to move converted file: $TEMPFILENAME"
 
-   rm -f "$LOCKFILE.ppplock"* # Delete the lockfile and its tmp file
+   rm -f "$LOCKFILE.ppplock"* # Delete the lockfile
    check_errs $? "Failed to remove lockfile."
 
    # [WORKAROUND] Wait for any other post-processing scripts to complete before exiting.
@@ -214,7 +216,7 @@ if [ ! -z "$1" ]; then
    if [[ PPP_CHECK -eq 1 ]]; then
        printf "$LOG_STRING_1$LOG_STRING_2$LOG_STRING_3$LOG_STRING_4$LOG_STRING_5" | tee -a $LOGFILE #Doing all together as to not stumble over multiple concurrent processes in log
    fi
-   printf "exiting. \n" | tee -a $LOGFILE
+   printf " exiting.\n" | tee -a $LOGFILE
 
 else
    echo "********************************************************" | tee -a $LOGFILE
@@ -223,7 +225,6 @@ else
    echo "********************************************************" | tee -a $LOGFILE
 fi
 
-rm -f "$TMPFOLDER/"*".ppplock"  # Make sure all lock files are removed, just in case there was an error somewhere in the script
-rm -f "$TMPFOLDER/$RANDFILENAME"
+rm -f "$LOCKFILE.ppplock"  # Only clean up own lock files, otherwise can remove one from another transcode
 
 sleep 5 #Time for things to settle down


### PR DESCRIPTION
3 main changes:

1) Log will no longer be spammed if there is a lockfile. instead message will print once and then '.' will be printed every minute as it waits.  

2)  mktemp in original implementation left artifacts in /tmp folder every time transcode would happen. These are now cleaned up immediately after mktemp is used (for lockfile and for mkv temp file).

3) There is no longer sledgehammer deletion of files that may have been made by other processes. If everything is working well then the script will clean up its own files only. So only tmp.* it creates and only lockfiles it creates.
